### PR TITLE
Update to rustix 0.38.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         toolchain:
           - nightly
-          - "1.63"
+          - "1.65"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         toolchain:
           - nightly
-          - "1.48"
+          - "1.63"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ std = ["rustix/std"]
 
 [dependencies]
 libc = { version = "0.2.98", default-features = false }
-rustix = { version = "0.37", default-features = false, features = ["io_uring", "mm", "time"] }
+rustix = { version = "0.38", default-features = false, features = ["io_uring", "mm", "time"] }
 
 [dev-dependencies]
 anyhow = "1"
-socket2 = "0.4"
+socket2 = "0.5"
 slab = "0.4"

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -12,11 +12,11 @@ use libc::epoll_event;
 use rustix::io_uring;
 
 use crate::types::{
-    sealed, AcceptFlags, Advice, AtFlags, DestinationSlot, Fixed, IoringAcceptFlags,
-    IoringAsyncCancelFlags, IoringFsyncFlags, IoringMsgringCmds, IoringMsgringFlags, IoringOp,
-    IoringPollFlags, IoringRecvFlags, IoringSendFlags, IoringSqeFlags, IoringTimeoutFlags,
-    IoringUserData, OFlags, OpenHow, RawFd, ReadWriteFlags, RecvFlags, RenameFlags, SendFlags,
-    SpliceFlags, Timespec,
+    sealed, Advice, AtFlags, DestinationSlot, Fixed, IoringAcceptFlags, IoringAsyncCancelFlags,
+    IoringFsyncFlags, IoringMsgringCmds, IoringMsgringFlags, IoringOp, IoringPollFlags,
+    IoringRecvFlags, IoringSendFlags, IoringSqeFlags, IoringTimeoutFlags, IoringUserData, OFlags,
+    OpenHow, RawFd, ReadWriteFlags, RecvFlags, RenameFlags, SendFlags, SocketFlags, SpliceFlags,
+    Timespec,
 };
 
 macro_rules! assign_fd {
@@ -650,7 +650,7 @@ opcode!(
         addrlen: { *mut libc::socklen_t },
         ;;
         file_index: Option<DestinationSlot> = None,
-        flags: AcceptFlags = AcceptFlags::empty()
+        flags: SocketFlags = SocketFlags::empty()
     }
 
     pub const CODE = IoringOp::Accept;
@@ -679,7 +679,7 @@ opcode!(
         fd: { impl sealed::UseFixed },
         ;;
         allocate_file_index: bool = false,
-        flags: AcceptFlags = AcceptFlags::empty()
+        flags: SocketFlags = SocketFlags::empty()
     }
 
     pub const CODE = IoringOp::Accept;

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ pub use rustix::io_uring::{
     IoringRegisterOp, IoringRestrictionOp, IoringRsrcFlags, IoringSendFlags, IoringSetupFlags,
     IoringSqFlags, IoringSqeFlags, IoringTimeoutFlags, RecvmsgOutFlags, SpliceFlags,
 };
-pub use rustix::net::{AcceptFlags, RecvFlags, SendFlags};
+pub use rustix::net::{RecvFlags, SendFlags, SocketFlags};
 pub use rustix::time::Timespec;
 
 pub(crate) mod sealed {


### PR DESCRIPTION
`rustix::net::AcceptFlags` was renamed to `rustix::net::SocketFlags`.