### PR TITLE
Use `core::ffi::c_void` insteead of `libc::c_void`.

### DIFF
--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -2,6 +2,7 @@
 // The entry point in this file can be found by searching for 'pub'.
 
 use std::cell::Cell;
+use std::ffi::c_void;
 use std::fmt;
 use std::io;
 use std::os::unix::io::AsRawFd;
@@ -22,7 +23,7 @@ type Bid = u16; // Buffer id
 /// An anonymous region of memory mapped using `mmap(2)`, not backed by a file
 /// but that is guaranteed to be page-aligned and zero-filled.
 pub struct AnonymousMmap {
-    addr: ptr::NonNull<libc::c_void>,
+    addr: ptr::NonNull<c_void>,
     len: usize,
 }
 
@@ -58,27 +59,27 @@ impl AnonymousMmap {
 
     /// Get a pointer to the memory.
     #[inline]
-    pub fn as_ptr(&self) -> *const libc::c_void {
+    pub fn as_ptr(&self) -> *const c_void {
         self.addr.as_ptr()
     }
 
     /// Get a mut pointer to the memory.
     #[inline]
-    pub fn as_ptr_mut(&self) -> *mut libc::c_void {
+    pub fn as_ptr_mut(&self) -> *mut c_void {
         self.addr.as_ptr()
     }
 
     /// Get a pointer to the data at the given offset.
     #[inline]
     #[allow(dead_code)]
-    pub unsafe fn offset(&self, offset: u32) -> *const libc::c_void {
+    pub unsafe fn offset(&self, offset: u32) -> *const c_void {
         self.as_ptr().add(offset as usize)
     }
 
     /// Get a mut pointer to the data at the given offset.
     #[inline]
     #[allow(dead_code)]
-    pub unsafe fn offset_mut(&self, offset: u32) -> *mut libc::c_void {
+    pub unsafe fn offset_mut(&self, offset: u32) -> *mut c_void {
         self.as_ptr_mut().add(offset as usize)
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::new_without_default)]
 
 use core::convert::TryInto;
+use core::ffi::c_void;
 use core::mem;
 
 use crate::squeue::Entry;
@@ -1099,7 +1100,7 @@ impl Fadvise {
 opcode!(
     /// Give advice about use of memory, equivalent to `madvise(2)`.
     pub struct Madvise {
-        addr: { *const libc::c_void },
+        addr: { *const c_void },
         len: { libc::off_t },
         advice: { Advice },
         ;;

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,5 +1,6 @@
 //! Some register syscall related types or parameters.
 
+use core::ffi::c_void;
 use core::{fmt, mem, ptr};
 
 use rustix::{io, io_uring};
@@ -12,7 +13,7 @@ use crate::types::{
 pub(crate) fn execute<Fd: AsFd>(
     fd: Fd,
     opcode: IoringRegisterOp,
-    arg: *const libc::c_void,
+    arg: *const c_void,
     len: u32,
 ) -> io::Result<u32> {
     unsafe { io_uring::io_uring_register(fd, opcode, arg, len) }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use core::ffi::c_void;
 use core::ptr;
 use core::sync::atomic;
 
@@ -8,7 +9,7 @@ use crate::types::OwnedFd;
 
 /// A region of memory mapped using `mmap(2)`.
 pub struct Mmap {
-    addr: ptr::NonNull<libc::c_void>,
+    addr: ptr::NonNull<c_void>,
     len: usize,
 }
 
@@ -39,13 +40,13 @@ impl Mmap {
 
     /// Get a pointer to the memory.
     #[inline]
-    pub fn as_mut_ptr(&self) -> *mut libc::c_void {
+    pub fn as_mut_ptr(&self) -> *mut c_void {
         self.addr.as_ptr()
     }
 
     /// Get a pointer to the data at the given offset.
     #[inline]
-    pub unsafe fn offset(&self, offset: u32) -> *mut libc::c_void {
+    pub unsafe fn offset(&self, offset: u32) -> *mut c_void {
         self.as_mut_ptr().add(offset as usize)
     }
 }


### PR DESCRIPTION
This doesn't change any behavior; it just makes it easier to see where in the code actual `libc` things are being used.