### PR TITLE
Update the MSRV to 1.65 and remove MIPS from CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,13 +64,12 @@ jobs:
       matrix:
         toolchain:
           - nightly
-          - "1.48"
+          - "1.65"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           - i686-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
-          - mips64-unknown-linux-gnuabi64
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The code uses `cast_mut`, which was introduced in Rust 1.65, so bump the MSRV to Rust 1.65.

Also, Rust Nightly does not currently have MIPS builds, so remove MIPS from CI for now.