### PR TITLE
Correctly handle coop taskrun

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -67,12 +67,10 @@ impl<'a> Submitter<'a> {
         }
     }
 
-    /// CQ ring is overflown
-    fn sq_cq_overflow(&self) -> bool {
+    /// CQ ring is overflown or a deferred task is runnable. Either case requires entering the kernel
+    fn sq_cq_overflow_or_taskrun(&self) -> bool {
         unsafe {
-            (*self.sq_flags).load(atomic::Ordering::Acquire)
-                & sys::IoringSqFlags::CQ_OVERFLOW.bits()
-                != 0
+            (*self.sq_flags).load(atomic::Ordering::Acquire) & (sys::IoringSqFlags::TASKRUN | sys::IoringSqFlags::CQ_OVERFLOW).bits() != 0
         }
     }
 
@@ -114,12 +112,12 @@ impl<'a> Submitter<'a> {
         let len = self.sq_len();
         let mut flags = sys::IoringEnterFlags::empty();
 
-        // This logic suffers from the fact the sq_cq_overflow and sq_need_wakeup
-        // each cause an atomic load of the same variable, self.sq_flags.
-        // In the hottest paths, when a server is running with sqpoll,
-        // this is going to be hit twice, when once would be sufficient.
+        // This logic suffers from the fact the sq_cq_overflow_or_taskrun and
+        // sq_need_wakeup each cause an atomic load of the same variable,
+        // self.sq_flags. In the hottest paths, when a server is running with
+        // sqpoll, this is going to be hit twice, when once would be sufficient.
 
-        if want > 0 || self.params.is_setup_iopoll() || self.sq_cq_overflow() {
+        if want > 0 || self.params.is_setup_iopoll() || self.sq_cq_overflow_or_taskrun() {
             flags |= sys::IoringEnterFlags::GETEVENTS;
         }
 
@@ -144,7 +142,7 @@ impl<'a> Submitter<'a> {
         let len = self.sq_len();
         let mut flags = sys::IoringEnterFlags::EXT_ARG;
 
-        if want > 0 || self.params.is_setup_iopoll() || self.sq_cq_overflow() {
+        if want > 0 || self.params.is_setup_iopoll() || self.sq_cq_overflow_or_taskrun() {
             flags |= sys::IoringEnterFlags::GETEVENTS;
         }
 


### PR DESCRIPTION
When coop taskrun or defer taskrun are set to defer running completion processing until the next system call (coop) or the start of the next io_uring_enter() call (defer), the taskrun flag needs to be checked. The kernel will set the taskrun flag if there are deferred completions that need additional processing in kernel space before they're available to the application. Here we update the check in the submission path to ensure that flag is checked and GETEVENTS is passed into io_uring_enter() when needed.

Port of https://github.com/tokio-rs/io-uring/pull/263 from the Tokio io-uring repo.