### PR TITLE
Remove internal usage of std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.63"
+          - "1.81"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
@@ -68,7 +68,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.63"
+          - "1.81"
         target:
           - i686-unknown-linux-gnu
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/jordanisaacs/rustix-uring"
 documentation = "https://docs.rs/rustix-uring"
 description = "The low-level `io_uring` userspace interface for Rust"
 categories = [ "asynchronous", "network-programming", "filesystem" ]
-rust-version = "1.63"
+rust-version = "1.81"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustix-uring"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jordan Isaacs <mail@jdisaacs.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ rust-version = "1.81"
 exclude = ["/flake.*", ".envrc"]
 members = [ "io-uring-test", "io-uring-bench" ]
 
-[features]
-default = ["std"]
-std = ["rustix/std", "bitflags/std"]
-
 [dependencies]
 bitflags = { version = "2.4.0", default-features = false }
 rustix = { version = "1.0.2", default-features = false, features = ["io_uring", "mm", "thread"] }
@@ -28,5 +24,6 @@ rustix = { version = "1.0.2", default-features = false, features = ["io_uring", 
 [dev-dependencies]
 libc = "0.2.98"
 anyhow = "1"
+rustix = "1.0.2"
 socket2 = "0.5"
 slab = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The crate only provides a summary of the parameters.
 //! For more detailed documentation, see manpage.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 #[macro_use]
 mod util;

--- a/src/register.rs
+++ b/src/register.rs
@@ -144,7 +144,7 @@ pub const SKIP_FILE: BorrowedFd<'static> = rustix::io_uring::IORING_REGISTER_FIL
 
 #[test]
 fn test_probe_layout() {
-    use std::alloc::Layout;
+    use core::alloc::Layout;
 
     let probe = Probe::new();
     assert_eq!(

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -1,10 +1,9 @@
 //! Submission Queue
 
+use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::mem;
 use core::sync::atomic;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 use crate::sys;
 use crate::util::{private, unsync_load, Mmap};
@@ -452,7 +451,6 @@ impl Display for PushError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for PushError {}
 
 impl<E: EntryMarker> Debug for SubmissionQueue<'_, E> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,9 +194,8 @@ impl Timespec {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<std::time::Duration> for Timespec {
-    fn from(value: std::time::Duration) -> Self {
+impl From<core::time::Duration> for Timespec {
+    fn from(value: core::time::Duration) -> Self {
         Timespec::new()
             .sec(value.as_secs())
             .nsec(value.subsec_nanos())
@@ -680,7 +679,7 @@ impl FutexWaitV {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use crate::types::sealed::Target;
 


### PR DESCRIPTION
std was used for the Error trait and Duration type, both of which are available in core.

Personally I feel it would be cleaner if the std feature was removed entirely (and dependents enabled std themselves as needed for rustix and/or bitflags). It's a bit jank that we enable features we don't need. However that would be a breaking change. Also, feature deprecation is [still not supported](https://github.com/rust-lang/rfcs/pull/3486) in Cargo.