### PR TITLE
Return negative CQE results as `Errno`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn main() -> io::Result<()> {
     let cqe = ring.completion().next().expect("completion queue is empty");
 
     assert_eq!(cqe.user_data().u64_(), 0x42);
-    assert!(cqe.result() >= 0, "read error: {}", cqe.result());
+    let _bytes_read = cqe.result().expect("read error");
 
     Ok(())
 }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -25,7 +25,7 @@ fn main() -> io::Result<()> {
     let cqe = ring.completion().next().expect("completion queue is empty");
 
     assert_eq!(cqe.user_data().u64_(), 0x42);
-    assert!(cqe.result() >= 0, "read error: {}", cqe.result());
+    let _bytes_read = cqe.result().expect("read error");
 
     Ok(())
 }

--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::net::TcpListener;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::{io, ptr};
+use std::ptr;
 
 use rustix_uring::{opcode, squeue, types, Errno, IoUring, SubmissionQueue};
 use slab::Slab;
@@ -100,17 +100,14 @@ fn main() -> anyhow::Result<()> {
         accept.push_to(&mut sq);
 
         for cqe in &mut cq {
-            let ret = cqe.result();
             let token_index = cqe.user_data().u64_() as usize;
-
-            if ret < 0 {
-                eprintln!(
-                    "token {:?} error: {:?}",
-                    token_alloc.get(token_index),
-                    io::Error::from_raw_os_error(-ret)
-                );
-                continue;
-            }
+            let ret = match cqe.result() {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("token {:?} error: {e:?}", token_alloc.get(token_index));
+                    continue;
+                }
+            };
 
             let token = &mut token_alloc[token_index];
             match token.clone() {

--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -116,7 +116,7 @@ fn main() -> anyhow::Result<()> {
 
                     accept.count += 1;
 
-                    let fd = ret;
+                    let fd = ret as i32;
                     let poll_token = token_alloc.insert(Token::Poll { fd });
 
                     let poll_e = opcode::PollAdd::new(types::Fd(fd), libc::POLLIN as _)

--- a/io-uring-test/src/tests/cancel.rs
+++ b/io-uring-test/src/tests/cancel.rs
@@ -1,6 +1,6 @@
 use crate::Test;
 use io_uring::types::CancelBuilder;
-use io_uring::{cqueue, opcode, squeue, types, IoUring};
+use io_uring::{cqueue, opcode, squeue, types, Errno, IoUring};
 use std::fs::File;
 use std::os::fd::FromRawFd;
 use std::os::unix::io::AsRawFd;
@@ -46,8 +46,8 @@ pub fn test_async_cancel_user_data<S: squeue::EntryMarker, C: cqueue::EntryMarke
     assert_eq!(cqes[0].user_data().u64_(), 2003);
     assert_eq!(cqes[1].user_data().u64_(), 2004);
 
-    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
-    assert_eq!(cqes[1].result(), 0); // the number of requests cancelled
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[1].result(), Ok(0)); // the number of requests cancelled
 
     Ok(())
 }
@@ -96,9 +96,9 @@ pub fn test_async_cancel_user_data_all<S: squeue::EntryMarker, C: cqueue::EntryM
     assert_eq!(cqes[1].user_data().u64_(), 2003);
     assert_eq!(cqes[2].user_data().u64_(), 2004);
 
-    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
-    assert_eq!(cqes[1].result(), -libc::ECANCELED); // -ECANCELED
-    assert_eq!(cqes[2].result(), 2); // the number of requests cancelled
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[1].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[2].result(), Ok(2)); // the number of requests cancelled
 
     Ok(())
 }
@@ -147,9 +147,9 @@ pub fn test_async_cancel_any<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[1].user_data().u64_(), 2004);
     assert_eq!(cqes[2].user_data().u64_(), 2005);
 
-    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
-    assert_eq!(cqes[1].result(), -libc::ECANCELED);
-    assert_eq!(cqes[2].result(), 2); // the number of requests cancelled
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[1].result(), Err(Errno::CANCELED));
+    assert_eq!(cqes[2].result(), Ok(2)); // the number of requests cancelled
 
     Ok(())
 }
@@ -196,8 +196,8 @@ pub fn test_async_cancel_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[0].user_data().u64_(), 2003);
     assert_eq!(cqes[1].user_data().u64_(), 2004);
 
-    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
-    assert_eq!(cqes[1].result(), 0);
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[1].result(), Ok(0));
 
     Ok(())
 }
@@ -247,9 +247,9 @@ pub fn test_async_cancel_fd_all<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[1].user_data().u64_(), 2004);
     assert_eq!(cqes[2].user_data().u64_(), 2005);
 
-    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
-    assert_eq!(cqes[1].result(), -libc::ECANCELED);
-    assert_eq!(cqes[2].result(), 2); // the number of requests cancelled
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[1].result(), Err(Errno::CANCELED));
+    assert_eq!(cqes[2].result(), Ok(2)); // the number of requests cancelled
 
     Ok(())
 }

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -1,5 +1,6 @@
 use crate::utils;
 use crate::Test;
+use io_uring::Errno;
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use std::ffi::CString;
 use std::fs;
@@ -78,7 +79,7 @@ pub fn test_file_fsync<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x03);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }
@@ -116,7 +117,7 @@ pub fn test_file_fsync_file_range<S: squeue::EntryMarker, C: cqueue::EntryMarker
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x04);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }
@@ -149,7 +150,7 @@ pub fn test_file_fallocate<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x10);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }
@@ -188,9 +189,9 @@ pub fn test_file_openat2<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x11);
-    assert!(cqes[0].result() > 0);
+    assert!(cqes[0].result().is_ok_and(|x| x > 0));
 
-    let fd = unsafe { fs::File::from_raw_fd(cqes[0].result()) };
+    let fd = unsafe { fs::File::from_raw_fd(cqes[0].result().unwrap()) };
 
     assert!(fd.metadata()?.is_file());
 
@@ -249,9 +250,9 @@ pub fn test_file_openat2_close_file_index<S: squeue::EntryMarker, C: cqueue::Ent
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x11);
         if round == 2 {
-            assert!(cqes[0].result() < 0); // expect no room
+            assert!(cqes[0].result().is_err()); // expect no room
         } else {
-            assert_eq!(cqes[0].result(), round); // expect auto selection to go 0, then 1.
+            assert_eq!(cqes[0].result(), Ok(round)); // expect auto selection to go 0, then 1.
         }
     }
 
@@ -271,7 +272,7 @@ pub fn test_file_openat2_close_file_index<S: squeue::EntryMarker, C: cqueue::Ent
 
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x12);
-        assert_eq!(cqes[0].result(), 0); // successful close iff result is 0
+        assert_eq!(cqes[0].result(), Ok(0)); // successful close iff result is 0
     }
 
     // Redo the tests but with manual selection of the file_index value,
@@ -307,9 +308,9 @@ pub fn test_file_openat2_close_file_index<S: squeue::EntryMarker, C: cqueue::Ent
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x11);
         if round == 2 {
-            assert!(cqes[0].result() < 0); // expect 2 won't fit, even though it is being asked for first.
+            assert!(cqes[0].result().is_err()); // expect 2 won't fit, even though it is being asked for first.
         } else {
-            assert_eq!(cqes[0].result(), 0); // success iff zero
+            assert_eq!(cqes[0].result(), Ok(0)); // success iff zero
         }
     }
 
@@ -329,7 +330,7 @@ pub fn test_file_openat2_close_file_index<S: squeue::EntryMarker, C: cqueue::Ent
 
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x12);
-        assert_eq!(cqes[0].result(), 0); // successful close iff result is 0
+        assert_eq!(cqes[0].result(), Ok(0)); // successful close iff result is 0
     }
     // If the fixed-socket operation worked properly, this must not fail.
     ring.submitter().unregister_files().unwrap();
@@ -388,9 +389,9 @@ pub fn test_file_openat_close_file_index<S: squeue::EntryMarker, C: cqueue::Entr
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x11);
         if round == 2 {
-            assert!(cqes[0].result() < 0); // expect no room
+            assert!(cqes[0].result().is_err()); // expect no room
         } else {
-            assert_eq!(cqes[0].result(), round); // expect auto selection to go 0, then 1.
+            assert_eq!(cqes[0].result(), Ok(round)); // expect auto selection to go 0, then 1.
         }
     }
 
@@ -410,7 +411,7 @@ pub fn test_file_openat_close_file_index<S: squeue::EntryMarker, C: cqueue::Entr
 
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x12);
-        assert_eq!(cqes[0].result(), 0); // successful close iff result is 0
+        assert_eq!(cqes[0].result(), Ok(0)); // successful close iff result is 0
     }
 
     // Redo the tests but with manual selection of the file_index value,
@@ -444,9 +445,9 @@ pub fn test_file_openat_close_file_index<S: squeue::EntryMarker, C: cqueue::Entr
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x11);
         if round == 2 {
-            assert!(cqes[0].result() < 0); // expect 2 won't fit, even though it is being asked for first.
+            assert!(cqes[0].result().is_err()); // expect 2 won't fit, even though it is being asked for first.
         } else {
-            assert_eq!(cqes[0].result(), 0); // success iff zero
+            assert_eq!(cqes[0].result(), Ok(0)); // success iff zero
         }
     }
 
@@ -466,7 +467,7 @@ pub fn test_file_openat_close_file_index<S: squeue::EntryMarker, C: cqueue::Entr
 
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 0x12);
-        assert_eq!(cqes[0].result(), 0); // successful close iff result is 0
+        assert_eq!(cqes[0].result(), Ok(0)); // successful close iff result is 0
     }
     // If the fixed-socket operation worked properly, this must not fail.
     ring.submitter().unregister_files().unwrap();
@@ -502,7 +503,7 @@ pub fn test_file_close<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x12);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }
@@ -566,9 +567,9 @@ pub fn test_file_cur_pos<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
     assert_eq!(cqes[2].user_data().u64_(), 0x03);
-    assert_eq!(cqes[0].result(), 22);
-    assert_eq!(cqes[1].result(), 22);
-    assert_eq!(cqes[2].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(22));
+    assert_eq!(cqes[1].result(), Ok(22));
+    assert_eq!(cqes[2].result(), Ok(text.len() as i32));
 
     assert_eq!(&output, text);
 
@@ -614,7 +615,7 @@ pub fn test_statx<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x99);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     // check
     let statxbuf2 = rustix::fs::statx(
@@ -652,7 +653,7 @@ pub fn test_statx<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x9a);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     assert_same_statx(&statxbuf3, &statxbuf2);
 
@@ -792,8 +793,8 @@ pub fn test_file_direct_write_read<S: squeue::EntryMarker, C: cqueue::EntryMarke
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), input.0.len() as i32);
-    assert_eq!(cqes[1].result(), input.0.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(input.0.len() as i32));
+    assert_eq!(cqes[1].result(), Ok(input.0.len() as i32));
 
     assert_eq!(input.0[..], output.0[..]);
     assert_eq!(input.0[0], 0xf9);
@@ -819,7 +820,7 @@ pub fn test_file_direct_write_read<S: squeue::EntryMarker, C: cqueue::EntryMarke
     assert_eq!(cqes[0].user_data().u64_(), 0x03);
 
     // when fs does not support Direct IO, it may fallback to buffered IO.
-    assert_eq_warn!(cqes[0].result(), -libc::EINVAL);
+    assert_eq_warn!(cqes[0].result(), Err(Errno::INVAL));
 
     Ok(())
 }
@@ -874,7 +875,7 @@ pub fn test_file_splice<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x33);
-    assert_eq!(cqes[0].result(), 1024);
+    assert_eq!(cqes[0].result(), Ok(1024));
 
     let mut output = [0; 1024];
     pipe_out.read_exact(&mut output)?;
@@ -918,7 +919,7 @@ pub fn test_ftruncate<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x33);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
     assert_eq!(
         fs::read(&file).expect("could not read truncated file"),
         &input[..512]
@@ -938,7 +939,7 @@ pub fn test_ftruncate<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x34);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
     assert_eq!(
         fs::metadata(&file)
             .expect("could not read truncated file")
@@ -985,7 +986,7 @@ pub fn test_fixed_fd_install<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
-    assert_eq!(cqes[0].result(), 1024);
+    assert_eq!(cqes[0].result(), Ok(1024));
     assert_eq!(output, input);
 
     let fixed_fd_install_e =
@@ -1003,7 +1004,7 @@ pub fn test_fixed_fd_install<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x02);
-    let fd = cqes[0].result();
+    let fd = cqes[0].result().unwrap();
     assert!(fd > 0);
     let mut file = unsafe { fs::File::from_raw_fd(fd) };
     file.read_exact(&mut output)?;

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -191,7 +191,7 @@ pub fn test_file_openat2<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[0].user_data().u64_(), 0x11);
     assert!(cqes[0].result().is_ok_and(|x| x > 0));
 
-    let fd = unsafe { fs::File::from_raw_fd(cqes[0].result().unwrap()) };
+    let fd = unsafe { fs::File::from_raw_fd(cqes[0].result().unwrap() as i32) };
 
     assert!(fd.metadata()?.is_file());
 
@@ -569,7 +569,7 @@ pub fn test_file_cur_pos<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[2].user_data().u64_(), 0x03);
     assert_eq!(cqes[0].result(), Ok(22));
     assert_eq!(cqes[1].result(), Ok(22));
-    assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[2].result(), Ok(text.len() as u32));
 
     assert_eq!(&output, text);
 
@@ -793,8 +793,8 @@ pub fn test_file_direct_write_read<S: squeue::EntryMarker, C: cqueue::EntryMarke
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), Ok(input.0.len() as i32));
-    assert_eq!(cqes[1].result(), Ok(input.0.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(input.0.len() as u32));
+    assert_eq!(cqes[1].result(), Ok(input.0.len() as u32));
 
     assert_eq!(input.0[..], output.0[..]);
     assert_eq!(input.0[0], 0xf9);
@@ -1006,7 +1006,7 @@ pub fn test_fixed_fd_install<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[0].user_data().u64_(), 0x02);
     let fd = cqes[0].result().unwrap();
     assert!(fd > 0);
-    let mut file = unsafe { fs::File::from_raw_fd(fd) };
+    let mut file = unsafe { fs::File::from_raw_fd(fd as i32) };
     file.read_exact(&mut output)?;
     assert_eq!(output, input);
 

--- a/io-uring-test/src/tests/futex.rs
+++ b/io-uring-test/src/tests/futex.rs
@@ -73,7 +73,7 @@ pub fn test_futex_wait<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), USER_DATA);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }
@@ -125,7 +125,7 @@ pub fn test_futex_wake<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), USER_DATA);
-    assert_eq!(cqes[0].result(), 1);
+    assert_eq!(cqes[0].result(), Ok(1));
 
     wait_thread.join().unwrap();
 
@@ -177,7 +177,7 @@ pub fn test_futex_waitv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), USER_DATA);
-    assert_eq!(cqes[0].result(), TRIGGER_IDX as _);
+    assert_eq!(cqes[0].result(), Ok(TRIGGER_IDX as _));
 
     Ok(())
 }

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -112,8 +112,8 @@ pub fn test_tcp_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
-    assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
+    assert_eq!(cqes[1].result(), Ok(text.len() as u32));
 
     assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
 
@@ -174,7 +174,7 @@ pub fn test_tcp_send_bundle<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
 
     assert_eq!(
         recv_stream
@@ -232,18 +232,18 @@ pub fn test_tcp_zero_copy_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMark
     // Send completion is ordered w.r.t recv
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert!(io_uring::cqueue::more(cqes[0].flags()));
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
 
     // Notification is not ordered w.r.t recv
     match (cqes[1].user_data().u64_(), cqes[2].user_data().u64_()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
-            assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+            assert_eq!(cqes[2].result(), Ok(text.len() as u32));
             assert_eq!(&output[..cqes[2].result().unwrap() as usize], text);
         }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
-            assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+            assert_eq!(cqes[1].result(), Ok(text.len() as u32));
             assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
         }
         _ => unreachable!(),
@@ -315,18 +315,18 @@ pub fn test_tcp_zero_copy_send_fixed<S: squeue::EntryMarker, C: cqueue::EntryMar
     // Send completion is ordered w.r.t recv
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert!(io_uring::cqueue::more(cqes[0].flags()));
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
 
     // Notification is not ordered w.r.t recv
     match (cqes[1].user_data().u64_(), cqes[2].user_data().u64_()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
-            assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+            assert_eq!(cqes[2].result(), Ok(text.len() as u32));
             assert_eq!(&output[..cqes[2].result().unwrap() as usize], text);
         }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
-            assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+            assert_eq!(cqes[1].result(), Ok(text.len() as u32));
             assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
         }
         _ => unreachable!(),
@@ -414,8 +414,8 @@ pub fn test_tcp_sendmsg_recvmsg<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
-    assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
+    assert_eq!(cqes[1].result(), Ok(text.len() as u32));
 
     assert_eq!(buf2, text);
 
@@ -501,18 +501,18 @@ pub fn test_tcp_zero_copy_sendmsg_recvmsg<S: squeue::EntryMarker, C: cqueue::Ent
     // Send completion is ordered w.r.t recv
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert!(io_uring::cqueue::more(cqes[0].flags()));
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
 
     // Notification is not ordered w.r.t recv
     match (cqes[1].user_data().u64_(), cqes[2].user_data().u64_()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
-            assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+            assert_eq!(cqes[2].result(), Ok(text.len() as u32));
             assert_eq!(&buf2[..cqes[2].result().unwrap() as usize], text);
         }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
-            assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+            assert_eq!(cqes[1].result(), Ok(text.len() as u32));
             assert_eq!(&buf2[..cqes[1].result().unwrap() as usize], text);
         }
         _ => unreachable!(),
@@ -556,7 +556,7 @@ pub fn test_tcp_accept<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x0e);
 
-    let fd = cqes[0].result().unwrap();
+    let fd = cqes[0].result().unwrap() as i32;
 
     unsafe {
         libc::close(fd);
@@ -660,7 +660,7 @@ pub fn test_tcp_accept_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     for cqe in cqes {
         assert_eq!(cqe.user_data().u64_(), 2002);
 
-        let fd = cqe.result().unwrap();
+        let fd = cqe.result().unwrap() as i32;
 
         unsafe {
             libc::close(fd);
@@ -1498,11 +1498,11 @@ pub fn test_socket<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 42);
-    assert!(cqes[0].result().unwrap() != plain_fd);
+    assert!(cqes[0].result().unwrap() as i32 != plain_fd);
     assert_eq!(cqes[0].flags(), cqueue::Flags::empty());
 
     // Close both sockets, to avoid leaking FDs.
-    let io_uring_socket = unsafe { Socket::from_raw_fd(cqes[0].result().unwrap()) };
+    let io_uring_socket = unsafe { Socket::from_raw_fd(cqes[0].result().unwrap() as i32) };
     drop(plain_socket);
     drop(io_uring_socket);
 
@@ -1881,7 +1881,7 @@ pub fn test_udp_send_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
             1 => {
                 // The receive, we should have received the test message here.
                 let n_received = cqe.result().unwrap();
-                assert_eq!(n_received, out_buf.len() as i32);
+                assert_eq!(n_received, out_buf.len() as u32);
                 assert_eq!(&in_buf[..n_received as usize], out_buf);
             }
             2 => {
@@ -1891,7 +1891,7 @@ pub fn test_udp_send_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
             3 => {
                 // The send that should have succeeded.
                 let n_sent = cqe.result().unwrap();
-                assert_eq!(n_sent, out_buf.len() as i32);
+                assert_eq!(n_sent, out_buf.len() as u32);
             }
             _ => unreachable!("We only submit user data 1, 2, and 3."),
         }

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -3,6 +3,7 @@ use crate::utils;
 use crate::Test;
 use io_uring::squeue::Flags;
 use io_uring::types::{BufRingEntry, Fd};
+use io_uring::Errno;
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use once_cell::sync::OnceCell;
 use std::convert::TryInto;
@@ -111,10 +112,10 @@ pub fn test_tcp_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), text.len() as i32);
-    assert_eq!(cqes[1].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[1].result(), Ok(text.len() as i32));
 
-    assert_eq!(&output[..cqes[1].result() as usize], text);
+    assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
 
     Ok(())
 }
@@ -173,7 +174,7 @@ pub fn test_tcp_send_bundle<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
-    assert_eq!(cqes[0].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
 
     assert_eq!(
         recv_stream
@@ -231,19 +232,19 @@ pub fn test_tcp_zero_copy_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMark
     // Send completion is ordered w.r.t recv
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert!(io_uring::cqueue::more(cqes[0].flags()));
-    assert_eq!(cqes[0].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
 
     // Notification is not ordered w.r.t recv
     match (cqes[1].user_data().u64_(), cqes[2].user_data().u64_()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
-            assert_eq!(cqes[2].result(), text.len() as i32);
-            assert_eq!(&output[..cqes[2].result() as usize], text);
+            assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+            assert_eq!(&output[..cqes[2].result().unwrap() as usize], text);
         }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
-            assert_eq!(cqes[1].result(), text.len() as i32);
-            assert_eq!(&output[..cqes[1].result() as usize], text);
+            assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+            assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
         }
         _ => unreachable!(),
     }
@@ -314,19 +315,19 @@ pub fn test_tcp_zero_copy_send_fixed<S: squeue::EntryMarker, C: cqueue::EntryMar
     // Send completion is ordered w.r.t recv
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert!(io_uring::cqueue::more(cqes[0].flags()));
-    assert_eq!(cqes[0].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
 
     // Notification is not ordered w.r.t recv
     match (cqes[1].user_data().u64_(), cqes[2].user_data().u64_()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
-            assert_eq!(cqes[2].result(), text.len() as i32);
-            assert_eq!(&output[..cqes[2].result() as usize], text);
+            assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+            assert_eq!(&output[..cqes[2].result().unwrap() as usize], text);
         }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
-            assert_eq!(cqes[1].result(), text.len() as i32);
-            assert_eq!(&output[..cqes[1].result() as usize], text);
+            assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+            assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
         }
         _ => unreachable!(),
     }
@@ -413,8 +414,8 @@ pub fn test_tcp_sendmsg_recvmsg<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), text.len() as i32);
-    assert_eq!(cqes[1].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[1].result(), Ok(text.len() as i32));
 
     assert_eq!(buf2, text);
 
@@ -500,19 +501,19 @@ pub fn test_tcp_zero_copy_sendmsg_recvmsg<S: squeue::EntryMarker, C: cqueue::Ent
     // Send completion is ordered w.r.t recv
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert!(io_uring::cqueue::more(cqes[0].flags()));
-    assert_eq!(cqes[0].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
 
     // Notification is not ordered w.r.t recv
     match (cqes[1].user_data().u64_(), cqes[2].user_data().u64_()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
-            assert_eq!(cqes[2].result(), text.len() as i32);
-            assert_eq!(&buf2[..cqes[2].result() as usize], text);
+            assert_eq!(cqes[2].result(), Ok(text.len() as i32));
+            assert_eq!(&buf2[..cqes[2].result().unwrap() as usize], text);
         }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
-            assert_eq!(cqes[1].result(), text.len() as i32);
-            assert_eq!(&buf2[..cqes[1].result() as usize], text);
+            assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+            assert_eq!(&buf2[..cqes[1].result().unwrap() as usize], text);
         }
         _ => unreachable!(),
     }
@@ -554,9 +555,8 @@ pub fn test_tcp_accept<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x0e);
-    assert!(cqes[0].result() >= 0);
 
-    let fd = cqes[0].result();
+    let fd = cqes[0].result().unwrap();
 
     unsafe {
         libc::close(fd);
@@ -609,7 +609,7 @@ pub fn test_tcp_accept_file_index<S: squeue::EntryMarker, C: cqueue::EntryMarker
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x0e);
-    assert_eq!(cqes[0].result(), 0); // success iff result is zero.
+    assert_eq!(cqes[0].result(), Ok(0)); // success iff result is zero.
 
     // end of <from accept unit test>
 
@@ -659,9 +659,8 @@ pub fn test_tcp_accept_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     for cqe in cqes {
         assert_eq!(cqe.user_data().u64_(), 2002);
-        assert!(cqe.result() >= 0);
 
-        let fd = cqe.result();
+        let fd = cqe.result().unwrap();
 
         unsafe {
             libc::close(fd);
@@ -693,8 +692,8 @@ pub fn test_tcp_accept_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[op1].user_data().u64_(), 2002);
     assert_eq!(cqes[op2].user_data().u64_(), 2003);
 
-    assert_eq!(cqes[op1].result(), -125); // -ECANCELED
-    assert_eq!(cqes[op2].result(), 0);
+    assert_eq!(cqes[op1].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[op2].result(), Ok(0));
 
     Ok(())
 }
@@ -742,7 +741,7 @@ pub fn test_tcp_accept_multi_file_index<S: squeue::EntryMarker, C: cqueue::Entry
     #[allow(clippy::needless_range_loop)]
     for round in 0..=1 {
         assert_eq!(cqes[round].user_data().u64_(), 2002);
-        assert!(cqes[round].result() >= 0);
+        assert!(cqes[round].result().is_ok());
 
         // The fixed descriptor will be closed when the
         // table is unregistered below.
@@ -774,8 +773,8 @@ pub fn test_tcp_accept_multi_file_index<S: squeue::EntryMarker, C: cqueue::Entry
     assert_eq!(cqes[op1].user_data().u64_(), 2002);
     assert_eq!(cqes[op2].user_data().u64_(), 2003);
 
-    assert_eq!(cqes[op1].result(), -125); // -ECANCELED
-    assert_eq!(cqes[op2].result(), 0);
+    assert_eq!(cqes[op1].result(), Err(Errno::CANCELED)); // -ECANCELED
+    assert_eq!(cqes[op2].result(), Ok(0));
 
     // If the fixed-socket operation worked properly, this must not fail.
     ring.submitter().unregister_files().unwrap();
@@ -820,7 +819,7 @@ pub fn test_tcp_connect<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x0f);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     let _ = listener.accept()?;
 
@@ -885,7 +884,7 @@ pub fn test_tcp_buffer_select<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x22);
-    assert_eq!(cqe.result(), 1024);
+    assert_eq!(cqe.result(), Ok(1024));
     assert_eq!(cqueue::buffer_select(cqe.flags()), Some(0));
     assert_eq!(&bufs[..1024], &input[..1024]);
 
@@ -905,7 +904,7 @@ pub fn test_tcp_buffer_select<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x23);
-    assert_eq!(cqe.result(), -libc::ENOBUFS);
+    assert_eq!(cqe.result(), Err(Errno::NOBUFS));
 
     // provides two bufs, one of which we will use, one we will free
     let mut bufs = vec![0; 2 * 1024];
@@ -940,7 +939,7 @@ pub fn test_tcp_buffer_select<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x25);
-    assert_eq!(cqe.result(), 256);
+    assert_eq!(cqe.result(), Ok(256));
 
     let (buf0, buf1) = bufs.split_at(1024);
     let bid = cqueue::buffer_select(cqe.flags()).expect("no buffer id");
@@ -963,7 +962,7 @@ pub fn test_tcp_buffer_select<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x26);
-    assert_eq!(cqe.result(), 1);
+    assert_eq!(cqe.result(), Ok(1));
 
     // remove bufs fail
     let remove_bufs_e = opcode::RemoveBuffers::new(1, 0xdeaf);
@@ -978,7 +977,7 @@ pub fn test_tcp_buffer_select<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x27);
-    assert_eq!(cqe.result(), -libc::ENOENT);
+    assert_eq!(cqe.result(), Err(Errno::NOENT));
 
     Ok(())
 }
@@ -1050,7 +1049,7 @@ pub fn test_tcp_buffer_select_recvmsg<S: squeue::EntryMarker, C: cqueue::EntryMa
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x27);
-    assert_eq!(cqe.result(), 1024); // -14 would mean EFAULT, bad address.
+    assert_eq!(cqe.result(), Ok(1024)); // -14 would mean EFAULT, bad address.
 
     let bid = cqueue::buffer_select(cqe.flags()).expect("no buffer id");
     if bid == INPUT_BID {
@@ -1138,7 +1137,7 @@ pub fn test_tcp_buffer_select_readv<S: squeue::EntryMarker, C: cqueue::EntryMark
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x2a);
-    assert_eq!(cqe.result(), 512);
+    assert_eq!(cqe.result(), Ok(512));
 
     let bid = cqueue::buffer_select(cqe.flags()).expect("no buffer id");
     assert_eq!(bid, INPUT_BID);
@@ -1188,7 +1187,7 @@ pub fn test_tcp_recv_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let cqe: cqueue::Entry = ring.completion().next().expect("cqueue is empty").into();
     assert_eq!(cqe.user_data().u64_(), 0x21);
-    assert_eq!(cqe.result(), 0);
+    assert_eq!(cqe.result(), Ok(0));
 
     // write all 1024 + 256
     send_stream.write_all(&input)?;
@@ -1210,20 +1209,20 @@ pub fn test_tcp_recv_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 3);
 
     assert_eq!(cqes[0].user_data().u64_(), 0x22);
-    assert_eq!(cqes[0].result(), 1024); // length 1024
+    assert_eq!(cqes[0].result(), Ok(1024)); // length 1024
     assert!(cqueue::more(cqes[0].flags()));
     assert_eq!(cqueue::buffer_select(cqes[0].flags()), Some(0));
     assert_eq!(&bufs[..1024], &input[..1024]);
 
     assert_eq!(cqes[1].user_data().u64_(), 0x22);
-    assert_eq!(cqes[1].result(), 256); // length 256
+    assert_eq!(cqes[1].result(), Ok(256)); // length 256
     assert!(cqueue::more(cqes[1].flags()));
     assert_eq!(cqueue::buffer_select(cqes[1].flags()), Some(1));
     assert_eq!(&bufs[1024..][..256], &input[1024..][..256]);
 
     assert_eq!(cqes[2].user_data().u64_(), 0x22);
     assert!(!cqueue::more(cqes[2].flags()));
-    assert_eq!(cqes[2].result(), -105); // No buffer space available
+    assert_eq!(cqes[2].result(), Err(Errno::NOBUFS)); // No buffer space available
 
     Ok(())
 }
@@ -1282,7 +1281,7 @@ pub fn test_tcp_recv_bundle<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
         assert_eq!(cqe.user_data().u64_(), 0x30);
         assert!(cqueue::buffer_select(cqe.flags()).is_some());
-        let mut remaining = cqe.result() as usize;
+        let mut remaining = cqe.result().unwrap() as usize;
         let bufs = buf_ring
             .rc
             .get_bufs(&buf_ring, remaining as u32, cqe.flags());
@@ -1355,7 +1354,7 @@ pub fn test_tcp_recv_multi_bundle<S: squeue::EntryMarker, C: cqueue::EntryMarker
 
     assert_eq!(cqe.user_data().u64_(), 0x31);
     assert!(cqueue::buffer_select(cqe.flags()).is_some());
-    let mut remaining = cqe.result() as usize;
+    let mut remaining = cqe.result().unwrap() as usize;
     let bufs = buf_ring
         .rc
         .get_bufs(&buf_ring, remaining as u32, cqe.flags());
@@ -1383,7 +1382,7 @@ pub fn test_tcp_recv_multi_bundle<S: squeue::EntryMarker, C: cqueue::EntryMarker
 
         assert_eq!(cqe.user_data().u64_(), 0x31);
         assert!(cqueue::buffer_select(cqe.flags()).is_some());
-        remaining = cqe.result() as usize;
+        remaining = cqe.result().unwrap() as usize;
         let second_bufs = buf_ring
             .rc
             .get_bufs(&buf_ring, remaining as u32, cqe.flags());
@@ -1404,9 +1403,9 @@ pub fn test_tcp_recv_multi_bundle<S: squeue::EntryMarker, C: cqueue::EntryMarker
         assert_eq!(cqe.user_data().u64_(), 0x31);
         assert!(!cqueue::more(cqe.flags()));
         if used_bufs < 5 {
-            assert_eq!(cqe.result(), 0); // Buffer space is avaialble
+            assert_eq!(cqe.result(), Ok(0)); // Buffer space is avaialble
         } else {
-            assert_eq!(cqe.result(), -105); // No buffer space available
+            assert_eq!(cqe.result(), Err(Errno::NOBUFS)); // No buffer space available
         }
     }
     buf_ring.rc.unregister(ring)?;
@@ -1445,7 +1444,7 @@ pub fn test_tcp_shutdown<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x28);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     let text = b"C'est la vie";
     let write_e = opcode::Write::new(sock_fd, text.as_ptr(), text.len() as _);
@@ -1461,7 +1460,7 @@ pub fn test_tcp_shutdown<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
-    assert_eq!(cqes[0].result(), -32); // EPIPE
+    assert_eq!(cqes[0].result(), Err(Errno::PIPE)); // EPIPE
 
     Ok(())
 }
@@ -1499,12 +1498,11 @@ pub fn test_socket<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 42);
-    assert!(cqes[0].result() >= 0);
-    assert!(cqes[0].result() != plain_fd);
+    assert!(cqes[0].result().unwrap() != plain_fd);
     assert_eq!(cqes[0].flags(), cqueue::Flags::empty());
 
     // Close both sockets, to avoid leaking FDs.
-    let io_uring_socket = unsafe { Socket::from_raw_fd(cqes[0].result()) };
+    let io_uring_socket = unsafe { Socket::from_raw_fd(cqes[0].result().unwrap()) };
     drop(plain_socket);
     drop(io_uring_socket);
 
@@ -1534,7 +1532,7 @@ pub fn test_socket<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 55);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
     assert_eq!(cqes[0].flags(), cqueue::Flags::empty());
 
     // If the fixed-socket operation worked properly, this must not fail.
@@ -1583,7 +1581,7 @@ pub fn test_udp_recvmsg_multishot<S: squeue::EntryMarker, C: cqueue::EntryMarker
         let cqes: Vec<io_uring::cqueue::Entry> = ring.completion().map(Into::into).collect();
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 11);
-        assert_eq!(cqes[0].result(), 0);
+        assert_eq!(cqes[0].result(), Ok(0));
         assert_eq!(cqes[0].flags(), cqueue::Flags::empty());
     }
 
@@ -1652,12 +1650,12 @@ pub fn test_udp_recvmsg_multishot<S: squeue::EntryMarker, C: cqueue::EntryMarker
         match cqe.user_data().u64_() {
             // send notifications
             55 => {
-                assert!(cqe.result() > 0);
+                assert!(cqe.result().unwrap() > 0);
                 assert!(!is_more);
             }
             // SendMsgZc with two notification
             66 => {
-                if cqe.result() > 0 {
+                if cqe.result().is_ok_and(|x| x > 0) {
                     assert!(is_more);
                 } else {
                     assert!(!is_more);
@@ -1665,7 +1663,7 @@ pub fn test_udp_recvmsg_multishot<S: squeue::EntryMarker, C: cqueue::EntryMarker
             }
             // RecvMsgMulti
             77 => {
-                assert!(cqe.result() > 0);
+                assert!(cqe.result().unwrap() > 0);
                 assert!(is_more);
                 let buf_id = io_uring::cqueue::buffer_select(cqe.flags()).unwrap();
                 let tmp_buf = &buffers[buf_id as usize];
@@ -1730,7 +1728,7 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
         let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 11);
-        assert_eq!(cqes[0].result(), 0);
+        assert_eq!(cqes[0].result(), Ok(0));
         assert_eq!(cqes[0].flags(), cqueue::Flags::empty());
     }
 
@@ -1781,17 +1779,17 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
         match cqe.user_data().u64_() {
             // send notifications
             55 => {
-                assert!(cqe.result() > 0);
+                assert!(cqe.result().unwrap() > 0);
                 assert!(!is_more);
             }
             // RecvMsgMulti
             77 => {
-                if cqe.result() == -105 {
+                if cqe.result() == Err(Errno::NOBUFS) {
                     // Ran out of buffers
                     continue;
                 }
 
-                assert!(cqe.result() > 0);
+                assert!(cqe.result().unwrap() > 0);
                 assert!(is_more);
                 let buf_id = cqueue::buffer_select(cqe.flags()).unwrap() % buffers.len() as u16;
                 let tmp_buf = &buffers[buf_id as usize];
@@ -1882,17 +1880,17 @@ pub fn test_udp_send_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         match cqe.user_data().u64_() {
             1 => {
                 // The receive, we should have received the test message here.
-                let n_received = cqe.result();
+                let n_received = cqe.result().unwrap();
                 assert_eq!(n_received, out_buf.len() as i32);
                 assert_eq!(&in_buf[..n_received as usize], out_buf);
             }
             2 => {
                 // The send should have failed because it had no destination address.
-                assert_eq!(cqe.result(), -libc::EDESTADDRREQ);
+                assert_eq!(cqe.result(), Err(Errno::DESTADDRREQ));
             }
             3 => {
                 // The send that should have succeeded.
-                let n_sent = cqe.result();
+                let n_sent = cqe.result().unwrap();
                 assert_eq!(n_sent, out_buf.len() as i32);
             }
             _ => unreachable!("We only submit user data 1, 2, and 3."),
@@ -1941,7 +1939,7 @@ pub fn test_udp_sendzc_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>
         let cqes: Vec<io_uring::cqueue::Entry> = ring.completion().map(Into::into).collect();
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data().u64_(), 11);
-        assert_eq!(cqes[0].result(), 0);
+        assert_eq!(cqes[0].result(), Ok(0));
         assert_eq!(cqes[0].flags(), cqueue::Flags::empty());
     }
 
@@ -1982,10 +1980,10 @@ pub fn test_udp_sendzc_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>
             // data finally arrived to server
             3 => {
                 let buf_index_1 = cqueue::buffer_select(cqe.flags()).unwrap();
-                assert_eq!(cqe.result(), 11);
+                assert_eq!(cqe.result(), Ok(11));
                 assert_eq!(&buffers[buf_index_1 as usize][..11], buf1);
             }
-            33 => match cqe.result() {
+            33 => match cqe.result().unwrap() {
                 // First SendZc notification
                 11 => {
                     assert!(cqueue::more(cqe.flags()));

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -24,7 +24,7 @@ pub fn test_nop<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x42);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }
@@ -145,7 +145,7 @@ pub fn test_debug_print<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), num_to_sub);
     for cqe in cqes {
         assert_eq!(cqe.user_data().u64_(), 0x42);
-        assert_eq!(cqe.result(), 0);
+        assert_eq!(cqe.result(), Ok(0));
     }
     println!("Empty: {:?}", ring.submission());
 
@@ -186,13 +186,13 @@ pub fn test_msg_ring_data<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let source_cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(source_cqes.len(), 1);
     assert_eq!(source_cqes[0].user_data().u64_(), 0);
-    assert_eq!(source_cqes[0].result(), 0);
+    assert_eq!(source_cqes[0].result(), Ok(0));
     assert_eq!(source_cqes[0].flags(), cqueue::Flags::empty());
 
     let dest_cqes: Vec<cqueue::Entry> = dest_ring.completion().map(Into::into).collect();
     assert_eq!(dest_cqes.len(), 1);
     assert_eq!(dest_cqes[0].user_data().u64_(), user_data);
-    assert_eq!(dest_cqes[0].result(), result);
+    assert_eq!(dest_cqes[0].result(), Ok(result));
     assert_eq!(dest_cqes[0].flags().bits(), 0);
 
     Ok(())
@@ -253,13 +253,13 @@ pub fn test_msg_ring_send_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         let source_cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
         assert_eq!(source_cqes.len(), 1);
         assert_eq!(source_cqes[0].user_data().u64_(), 0);
-        assert_eq!(source_cqes[0].result(), 0);
+        assert_eq!(source_cqes[0].result(), Ok(0));
         assert_eq!(source_cqes[0].flags(), cqueue::Flags::empty());
 
         let dest_cqes: Vec<cqueue::Entry> = temp_ring.completion().map(Into::into).collect();
         assert_eq!(dest_cqes.len(), 1);
         assert_eq!(dest_cqes[0].user_data().u64_(), 22);
-        assert_eq!(dest_cqes[0].result(), 0);
+        assert_eq!(dest_cqes[0].result(), Ok(0));
         assert_eq!(dest_cqes[0].flags(), cqueue::Flags::empty());
     }
 
@@ -284,13 +284,13 @@ pub fn test_msg_ring_send_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         let source_cqes: Vec<cqueue::Entry> = temp_ring.completion().map(Into::into).collect();
         assert_eq!(source_cqes.len(), 1);
         assert_eq!(source_cqes[0].user_data().u64_(), 0);
-        assert_eq!(source_cqes[0].result(), 0);
+        assert_eq!(source_cqes[0].result(), Ok(0));
         assert_eq!(source_cqes[0].flags(), cqueue::Flags::empty());
 
         let dest_cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
         assert_eq!(dest_cqes.len(), 1);
         assert_eq!(dest_cqes[0].user_data().u64_(), 44);
-        assert_eq!(dest_cqes[0].result(), 0);
+        assert_eq!(dest_cqes[0].result(), Ok(0));
         assert_eq!(dest_cqes[0].flags(), cqueue::Flags::empty());
     }
 

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -192,7 +192,7 @@ pub fn test_msg_ring_data<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let dest_cqes: Vec<cqueue::Entry> = dest_ring.completion().map(Into::into).collect();
     assert_eq!(dest_cqes.len(), 1);
     assert_eq!(dest_cqes[0].user_data().u64_(), user_data);
-    assert_eq!(dest_cqes[0].result(), Ok(result));
+    assert_eq!(dest_cqes[0].result(), Ok(result as u32));
     assert_eq!(dest_cqes[0].flags().bits(), 0);
 
     Ok(())

--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -568,7 +568,7 @@ where
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
     Ok(())
 }
 

--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -568,7 +568,7 @@ where
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
-    assert_eq!(cqes[0].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
     Ok(())
 }
 
@@ -606,11 +606,8 @@ where
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x02);
 
-    let result = cqes[0].result();
-    if result < 0 {
-        // Expect ENOBUFS when the buf_ring is empty.
-        return Err(io::Error::from_raw_os_error(-result));
-    }
+    // Expect ENOBUFS when the buf_ring is empty.
+    let result = cqes[0].result()?;
 
     let result = result as u32;
     assert_eq!(result, len);

--- a/io-uring-test/src/tests/register_buffers.rs
+++ b/io-uring-test/src/tests/register_buffers.rs
@@ -139,7 +139,7 @@ fn _test_register_buffers<
         assert!(ce.user_data().u64_() < BUFFERS as u64);
         assert_eq!(
             ce.result(),
-            Ok(BUF_SIZE as i32),
+            Ok(BUF_SIZE as u32),
             "WriteFixed operation {} failed",
             index
         );
@@ -177,7 +177,7 @@ fn _test_register_buffers<
         assert!(ce.user_data().u64_() < BUFFERS as u64);
         assert_eq!(
             ce.result(),
-            Ok(BUF_SIZE as i32),
+            Ok(BUF_SIZE as u32),
             "ReadFixed operation {} failed",
             index
         );

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -34,7 +34,7 @@ pub fn test_timeout<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x09);
-    assert_eq!(cqes[0].result(), -libc::ETIME);
+    assert_eq!(cqes[0].result(), Err(Errno::TIME));
 
     // add timeout but no
 
@@ -63,7 +63,7 @@ pub fn test_timeout<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x0b);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     // timeout
 
@@ -75,7 +75,7 @@ pub fn test_timeout<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x0a);
-    assert_eq!(cqes[0].result(), -libc::ETIME);
+    assert_eq!(cqes[0].result(), Err(Errno::TIME));
 
     Ok(())
 }
@@ -116,8 +116,8 @@ pub fn test_timeout_count<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x0c);
     assert_eq!(cqes[1].user_data().u64_(), 0x0d);
-    assert_eq!(cqes[0].result(), 0);
-    assert_eq!(cqes[1].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
+    assert_eq!(cqes[1].result(), Ok(0));
 
     Ok(())
 }
@@ -170,8 +170,8 @@ pub fn test_timeout_remove<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x10);
     assert_eq!(cqes[1].user_data().u64_(), 0x11);
-    assert_eq!(cqes[0].result(), -libc::ECANCELED);
-    assert_eq!(cqes[1].result(), 0);
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED));
+    assert_eq!(cqes[1].result(), Ok(0));
 
     Ok(())
 }
@@ -226,8 +226,8 @@ pub fn test_timeout_update<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x10);
     assert_eq!(cqes[1].user_data().u64_(), 0x11);
-    assert_eq!(cqes[0].result(), -libc::ETIME);
-    assert_eq!(cqes[1].result(), 0);
+    assert_eq!(cqes[0].result(), Err(Errno::TIME));
+    assert_eq!(cqes[1].result(), Ok(0));
 
     Ok(())
 }
@@ -280,8 +280,8 @@ pub fn test_timeout_cancel<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x10);
     assert_eq!(cqes[1].user_data().u64_(), 0x11);
-    assert_eq!(cqes[0].result(), -libc::ECANCELED);
-    assert_eq!(cqes[1].result(), 0);
+    assert_eq!(cqes[0].result(), Err(Errno::CANCELED));
+    assert_eq!(cqes[1].result(), Ok(0));
 
     Ok(())
 }
@@ -328,7 +328,7 @@ pub fn test_timeout_abs<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x19);
-    assert_eq!(cqes[0].result(), -libc::ETIME);
+    assert_eq!(cqes[0].result(), Err(Errno::TIME));
 
     Ok(())
 }
@@ -377,7 +377,7 @@ pub fn test_timeout_submit_args<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data().u64_(), 0x1c);
-    assert_eq!(cqes[0].result(), 0);
+    assert_eq!(cqes[0].result(), Ok(0));
 
     Ok(())
 }

--- a/io-uring-test/src/utils.rs
+++ b/io-uring-test/src/utils.rs
@@ -84,8 +84,8 @@ pub fn write_read<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
-    assert_eq!(cqes[1].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[0].result(), Ok(text.len() as u32));
+    assert_eq!(cqes[1].result(), Ok(text.len() as u32));
 
     assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
 
@@ -128,8 +128,8 @@ pub fn writev_readv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), Ok((text.len() + text2.len()) as i32));
-    assert_eq!(cqes[1].result(), Ok((text.len() + text2.len()) as i32));
+    assert_eq!(cqes[0].result(), Ok((text.len() + text2.len()) as u32));
+    assert_eq!(cqes[1].result(), Ok((text.len() + text2.len()) as u32));
 
     assert_eq!(&output, text);
     assert_eq!(&output2[..], text2);

--- a/io-uring-test/src/utils.rs
+++ b/io-uring-test/src/utils.rs
@@ -84,10 +84,10 @@ pub fn write_read<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), text.len() as i32);
-    assert_eq!(cqes[1].result(), text.len() as i32);
+    assert_eq!(cqes[0].result(), Ok(text.len() as i32));
+    assert_eq!(cqes[1].result(), Ok(text.len() as i32));
 
-    assert_eq!(&output[..cqes[1].result() as usize], text);
+    assert_eq!(&output[..cqes[1].result().unwrap() as usize], text);
 
     Ok(())
 }
@@ -128,8 +128,8 @@ pub fn writev_readv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data().u64_(), 0x01);
     assert_eq!(cqes[1].user_data().u64_(), 0x02);
-    assert_eq!(cqes[0].result(), (text.len() + text2.len()) as i32);
-    assert_eq!(cqes[1].result(), (text.len() + text2.len()) as i32);
+    assert_eq!(cqes[0].result(), Ok((text.len() + text2.len()) as i32));
+    assert_eq!(cqes[1].result(), Ok((text.len() + text2.len()) as i32));
 
     assert_eq!(&output, text);
     assert_eq!(&output2[..], text2);

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -215,7 +215,7 @@ impl Entry {
     /// equivalent to the return value of the `read(2)` system call.  If the operation failed, the
     /// errno is returned.
     #[inline]
-    pub fn result(&self) -> Result<i32, Errno> {
+    pub fn result(&self) -> Result<u32, Errno> {
         // The following text is found in many io_uring man pages:
         //
         // > Note that where synchronous system calls will return -1 on failure
@@ -225,10 +225,10 @@ impl Entry {
         // Furthermore, I believe a negative value in the `res` field is
         // _always_ a negated errno.  We return a `Result` instead for
         // convenience.
-        if self.0.res < 0 {
-            Err(Errno::from_raw_os_error(-self.0.res))
+        if let Ok(x) = u32::try_from(self.0.res) {
+            Ok(x)
         } else {
-            Ok(self.0.res)
+            Err(Errno::from_raw_os_error(-self.0.res))
         }
     }
 

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -232,6 +232,13 @@ impl Entry {
         }
     }
 
+    /// The operation-specific result code. For example, for a [`Read`](crate::opcode::Read)
+    /// operation this is equivalent to the return value of the `read(2)` system call.
+    #[inline]
+    pub fn raw_result(&self) -> i32 {
+        self.0.res
+    }
+
     /// The user data of the request, as set by
     /// [`Entry::user_data`](crate::squeue::Entry::user_data) on the submission queue event.
     #[inline]

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -9,6 +9,7 @@ use crate::sys;
 use crate::util::{private, unsync_load, Mmap};
 
 use bitflags::bitflags;
+use rustix::io::Errno;
 
 pub(crate) struct Inner<E: EntryMarker> {
     head: *const atomic::AtomicU32,
@@ -209,11 +210,26 @@ impl<E: EntryMarker> ExactSizeIterator for CompletionQueue<'_, E> {
 }
 
 impl Entry {
-    /// The operation-specific result code. For example, for a [`Read`](crate::opcode::Read)
-    /// operation this is equivalent to the return value of the `read(2)` system call.
+    /// The result of the operation.  If the operation succeeded, this is the operation-specific
+    /// return value.  For example, for a [`Read`](crate::opcode::Read) operation this is
+    /// equivalent to the return value of the `read(2)` system call.  If the operation failed, the
+    /// errno is returned.
     #[inline]
-    pub fn result(&self) -> i32 {
-        self.0.res
+    pub fn result(&self) -> Result<i32, Errno> {
+        // The following text is found in many io_uring man pages:
+        //
+        // > Note that where synchronous system calls will return -1 on failure
+        // > and set errno to the actual error value, io_uring never uses errno.
+        // > Instead it returns the negated errno directly in the CQE res field.
+        //
+        // Furthermore, I believe a negative value in the `res` field is
+        // _always_ a negated errno.  We return a `Result` instead for
+        // convenience.
+        if self.0.res < 0 {
+            Err(Errno::from_raw_os_error(-self.0.res))
+        } else {
+            Ok(self.0.res)
+        }
     }
 
     /// The user data of the request, as set by


### PR DESCRIPTION
The following text is found in many io_uring man pages:

> Note that where synchronous system calls will return -1 on failure
> and set errno to the actual error value, io_uring never uses errno.
> Instead it returns the negated errno directly in the CQE res field.

Furthermore, I believe a negative value in the `res` field is _always_ a negated errno.  Converting negative values to `rustix::io::Errno` is convenient.