### PR TITLE
Rename PollAdd's "flags" arg to "poll_mask" and make it type-safe

### DIFF
--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -3,6 +3,7 @@ use std::net::TcpListener;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::ptr;
 
+use rustix::event::epoll::EventFlags;
 use rustix_uring::{opcode, squeue, types, Errno, IoUring, SubmissionQueue};
 use slab::Slab;
 
@@ -119,7 +120,7 @@ fn main() -> anyhow::Result<()> {
                     let fd = ret as i32;
                     let poll_token = token_alloc.insert(Token::Poll { fd });
 
-                    let poll_e = opcode::PollAdd::new(types::Fd(fd), libc::POLLIN as _)
+                    let poll_e = opcode::PollAdd::new(types::Fd(fd), EventFlags::IN)
                         .build()
                         .user_data(poll_token as u64);
 
@@ -197,7 +198,7 @@ fn main() -> anyhow::Result<()> {
 
                         *token = Token::Poll { fd };
 
-                        opcode::PollAdd::new(types::Fd(fd), libc::POLLIN as _)
+                        opcode::PollAdd::new(types::Fd(fd), EventFlags::IN)
                             .build()
                             .user_data(token_index as u64)
                     } else {

--- a/io-uring-test/src/tests/cancel.rs
+++ b/io-uring-test/src/tests/cancel.rs
@@ -1,6 +1,7 @@
 use crate::Test;
 use io_uring::types::CancelBuilder;
 use io_uring::{cqueue, opcode, squeue, types, Errno, IoUring};
+use rustix::event::epoll::EventFlags;
 use std::fs::File;
 use std::os::fd::FromRawFd;
 use std::os::unix::io::AsRawFd;
@@ -169,7 +170,7 @@ pub fn test_async_cancel_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let _fd = create_dummy_fd()?;
     let fd = types::Fd(_fd.as_raw_fd());
-    let poll_e = opcode::PollAdd::new(fd, libc::POLLIN as _).build();
+    let poll_e = opcode::PollAdd::new(fd, EventFlags::IN).build();
 
     // Cancel one poll request matching FD
     let builder = CancelBuilder::fd(fd);
@@ -218,7 +219,7 @@ pub fn test_async_cancel_fd_all<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     let _fd = create_dummy_fd()?;
     let fd = types::Fd(_fd.as_raw_fd());
-    let poll_e = opcode::PollAdd::new(fd, libc::POLLIN as _).build();
+    let poll_e = opcode::PollAdd::new(fd, EventFlags::IN).build();
 
     // Cancel all requests matching FD
     let builder = CancelBuilder::fd(fd).all();

--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -1,5 +1,6 @@
 use crate::Test;
 use io_uring::{cqueue, opcode, squeue, types, Errno, IoUring};
+use rustix::event::epoll::EventFlags;
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -27,7 +28,7 @@ pub fn test_eventfd_poll<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         File::from_raw_fd(fd)
     };
 
-    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
+    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), EventFlags::IN);
 
     unsafe {
         let mut queue = ring.submission();
@@ -76,7 +77,7 @@ pub fn test_eventfd_poll_remove<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     // add poll
 
-    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
+    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), EventFlags::IN);
 
     unsafe {
         let mut queue = ring.submission();
@@ -141,7 +142,7 @@ pub fn test_eventfd_poll_remove_failed<S: squeue::EntryMarker, C: cqueue::EntryM
 
     // add poll
 
-    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
+    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), EventFlags::IN);
 
     unsafe {
         let mut queue = ring.submission();
@@ -201,7 +202,7 @@ pub fn test_eventfd_poll_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         File::from_raw_fd(fd)
     };
 
-    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _).multi(true);
+    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), EventFlags::IN).multi(true);
 
     unsafe {
         let mut queue = ring.submission();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -330,7 +330,7 @@ opcode! {
         /// The bits that may be set in `flags` are defined in `<poll.h>`,
         /// and documented in `poll(2)`.
         fd: { impl sealed::UseFixed },
-        flags: { u32 },
+        flags: { rustix::event::epoll::EventFlags },
         ;;
         multi: bool = false
     }
@@ -348,10 +348,11 @@ opcode! {
         }
 
         #[cfg(target_endian = "little")] {
-            sqe.op_flags.poll32_events = flags;
+            sqe.op_flags.poll32_events = flags.bits();
         }
 
         #[cfg(target_endian = "big")] {
+            let flags = flags.bits();
             let x = flags << 16;
             let y = flags >> 16;
             let flags = x | y;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -330,7 +330,7 @@ opcode! {
         /// The bits that may be set in `flags` are defined in `<poll.h>`,
         /// and documented in `poll(2)`.
         fd: { impl sealed::UseFixed },
-        flags: { rustix::event::epoll::EventFlags },
+        poll_mask: { rustix::event::epoll::EventFlags },
         ;;
         multi: bool = false
     }
@@ -338,7 +338,7 @@ opcode! {
     pub const CODE = sys::IoringOp::PollAdd;
 
     pub fn build(self) -> Entry {
-        let PollAdd { fd, flags, multi } = self;
+        let PollAdd { fd, poll_mask, multi } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
@@ -348,15 +348,15 @@ opcode! {
         }
 
         #[cfg(target_endian = "little")] {
-            sqe.op_flags.poll32_events = flags.bits();
+            sqe.op_flags.poll32_events = poll_mask.bits();
         }
 
         #[cfg(target_endian = "big")] {
-            let flags = flags.bits();
-            let x = flags << 16;
-            let y = flags >> 16;
-            let flags = x | y;
-            sqe.op_flags.poll32_events = flags;
+            let poll_mask = poll_mask.bits();
+            let x = poll_mask << 16;
+            let y = poll_mask >> 16;
+            let poll_mask = x | y;
+            sqe.op_flags.poll32_events = poll_mask;
         }
 
         Entry(sqe)


### PR DESCRIPTION
The "io_uring_prep_poll_add" man page refers to this field as "poll_mask".  I think it's worth following their naming, since `io_uring_prep_poll_update()` contains an unrelated field called "flags", in addition to "poll_mask".  (This opcode is not yet supported by rustix-uring, but I imagine it might be in the future.)