### PR TITLE
Add IoUring::submit_all()

### DIFF
--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -316,7 +316,7 @@ impl<E: EntryMarker> SubmissionQueue<'_, E> {
     }
 
     #[inline]
-    unsafe fn push_unchecked(&mut self, entry: &E) {
+    pub(crate) unsafe fn push_unchecked(&mut self, entry: &E) {
         *self
             .queue
             .sqes


### PR DESCRIPTION
Sometimes you have a bunch of SQEs you want to submit.  They may or may not fit in the squeue, but either way you just want to keep submitting in a loop until all the SQEs are submitted.

This PR adds a `submit_all()` method which does this for you.  It's named in analogy with `std::io::Write::write_all()`, which does something similar.

---

It's possibly more correct to check for and ignore `ErrorKind::Interrupted` when calling `submit()`.  I haven't seen this error happen in practice so I'm not sure.